### PR TITLE
Update log_loader.py

### DIFF
--- a/loader/log_loader.py
+++ b/loader/log_loader.py
@@ -52,7 +52,7 @@ def parse_log(es_writer, file_path='data/the_bad.xml', initialize=True):
         #    'eventlogs'
         #    get_log_id(json.dumps(row).encode('utf-8')),
         #    row
-        )
+        #)
         processed_logs.append(
             get_bulk_prepped_log(
                 get_log_id(json.dumps(row).encode('utf-8')),


### PR DESCRIPTION
Resolves the following error:

loader_1            |   File "log_loader.py", line 55
loader_1            |     )
loader_1            |     ^
loader_1            | SyntaxError: invalid syntax